### PR TITLE
Some fixes for the gathering script

### DIFF
--- a/ditto-gathering-users.py
+++ b/ditto-gathering-users.py
@@ -74,8 +74,6 @@ for staker in address_obj:
 
 print("= totalStakingShareSeconds:{}\n= Number of users: {}\n".format(totalStakingShareSeconds, len(userStakingShareSeconds)))
 
-totalRewards = 0
-
 # Generate Ditto Claim list and Balance 
 with open('ditto_list_claim.csv', 'w', encoding='utf8') as file:
   writer = csv.writer(file)
@@ -90,7 +88,3 @@ with open('ditto_list_claim.csv', 'w', encoding='utf8') as file:
 
       print("{},{}".format(address,amount_fmt))
       writer.writerows = (address, amount_fmt)
-
-      totalRewards += claim_amount
-
-print("Total rewards: {}".format(totalRewards))

--- a/ditto-gathering-users.py
+++ b/ditto-gathering-users.py
@@ -6,6 +6,8 @@ from web3 import Web3
 from time import sleep, time
 from eth_utils import address
 from datetime import datetime
+import time
+import math
 
 HTTP_PROVIDER_URL = "https://bsc-dataseed.binance.org/"
 STAKING_CONTRACT = "0x27Da7Bc5CcB7c31baaeEA8a04CC8Bf0085017208"
@@ -14,6 +16,8 @@ with open('src/abis/DittoStaking.json') as f:
 
 w3 = Web3(Web3.HTTPProvider(HTTP_PROVIDER_URL))
 staking_contract = w3.eth.contract(STAKING_CONTRACT, abi=STAKING_CONTRACT_ABI)
+
+TOTAL_REWARDS = 250 * 1e18
 
 def run_query(query):  # A simple function to use requests.post to make the API call.
     request = requests.post('https://graphql.bitquery.io/',
@@ -45,27 +49,48 @@ query {
   }
 """
 
-result = run_query(query) 
+result = run_query(query)
 address_obj = result["data"]["ethereum"]["arguments"]
+
 totalStakingShareSeconds = 0
+userStakingShareSeconds = {}
+now = time.time()
+
+print("Collecting user totals...")
 
 # Get totalStakingShareSeconds
 for staker in address_obj:
-  staking_address = address.to_checksum_address(staker["reference"]["address"])  
-  userTotals = staking_contract.functions.userTotals(staking_address).call()
-  if (userTotals[1] > 0):
-    totalStakingShareSeconds = userTotals[1] + totalStakingShareSeconds
+  staking_address = address.to_checksum_address(staker["reference"]["address"])
 
-# print('Total Events Staking: {}'.format(len(address_obj)))
-# print('Total Time Staking: {}'.format(datetime.datetime(totalStakingShareSeconds)))
+  if staking_address in userStakingShareSeconds:
+    continue  # Skip duplicates
+  
+  (stakingShares, stakingShareSeconds, lastAccountingTimestamp) = staking_contract.functions.userTotals(staking_address).call()
+
+  stakingShareSeconds = stakingShareSeconds + (now - lastAccountingTimestamp) * stakingShares
+
+  userStakingShareSeconds[staking_address] = stakingShareSeconds
+  totalStakingShareSeconds = stakingShareSeconds + totalStakingShareSeconds
+
+print("= totalStakingShareSeconds:{}\n= Number of users: {}\n".format(totalStakingShareSeconds, len(userStakingShareSeconds)))
+
+totalRewards = 0
 
 # Generate Ditto Claim list and Balance 
 with open('ditto_list_claim.csv', 'w', encoding='utf8') as file:
   writer = csv.writer(file)
   writer.writerow = [("address", "amount")]
-  for staker_address in address_obj:
-    staking_address = address.to_checksum_address(staker_address["reference"]["address"])  
-    userTotals = staking_contract.functions.userTotals(staking_address).call()
-    if (userTotals[1] > 0):
-      claim_balance = userTotals[1]/totalStakingShareSeconds
-      writer.writerows = (staking_address, claim_balance)
+
+  for address,stakingShareSeconds in userStakingShareSeconds.items():
+
+    if (stakingShareSeconds > 0):
+      claim_amount = math.floor(TOTAL_REWARDS * stakingShareSeconds / totalStakingShareSeconds)
+
+      amount_fmt = "%d" % claim_amount
+
+      print("{},{}".format(address,amount_fmt))
+      writer.writerows = (address, amount_fmt)
+
+      totalRewards += claim_amount
+
+print("Total rewards: {}".format(totalRewards))


### PR DESCRIPTION
- Also consider user's staking share seconds from last accounting timestamp to current time
- Remove duplicate address entries
- Refactor so the API needs to be queried only once
- Correctly calculate the amount for each user in BNB (18 decimals)

## Output

```
$ python ditto-gathering-users.py 
Collecting user totals...
= totalStakingShareSeconds:3.0304882472289756e+30
= Number of users: 320

0x4e00F9E963B2D65C3a1169A9247917c7cb85cd0c,1028051002259534
0x62de3D0bBd1F2d30aEB97C393d148cEc5087fa61,30293007516823672
0x48089520F33dC34d7e2cA677359416B7A735D7B7,2655857532814309
0xB2a4584407bB58A02a4183D20A4fBC1dB4c55B92,1024511108111639040
0xb500d933b379bC33fC8332aDf917495917e3915c,15779493072815678
(...)
```

Also verified that it matches what is displayed in the dashboard and that the rewards add up to the correct total amount.